### PR TITLE
fix: #44 use mkdir -p so make eo is idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ eo:
 	$(MAKE) -C src/eo/prim
 	$(MAKE) -C src/eo/dijkstra
 	$(MAKE) -C src/eo/fordfulkerson
-	mkdir target target/run
+	mkdir -p target/run
 
 run: target/run/kruskal.txt target/run/prim.txt target/run/dijkstra.txt target/run/fordfulkerson.txt
 


### PR DESCRIPTION
The top-level `Makefile` ends the `eo` target with `mkdir target target/run`, which has no `-p` flag and aborts on rerun. Once `target/` already exists, the next `make`, `make eo`, or `make compile` invocation fails with `mkdir: cannot create directory 'target': File exists` and the build is reported broken without anything having actually changed in the sources. This is the surface symptom flagged in #44 and one slice of the broader breakage tracked in #40.

After this change the recipe is `mkdir -p target/run`, which creates both `target/` and `target/run/` in one call and stays silent when they already exist. A subsequent `make eo` on a populated working copy is now a no-op for this step instead of a hard failure, and the recipe matches the convention already used by the `target/run/%.txt:` rule a few lines below.

Verified locally by running `make eo` twice in a row on a clean checkout — the first invocation creates the directories, the second is silent, and the `eo` target no longer returns a non-zero exit code on idempotent rebuilds. Other build failures unrelated to directory creation are not in scope here.

Closes #44
